### PR TITLE
Support passing specific username as an option

### DIFF
--- a/Firefox_extract_cookies.js
+++ b/Firefox_extract_cookies.js
@@ -3,12 +3,11 @@ ObjC.import('Foundation');
 app = Application.currentApplication();
 app.includeStandardAdditions = true;
 
-function cookie_extract(){
+function cookie_extract({user = $.NSUserName().js} = {}){
 var output = "";
 var fileMan = $.NSFileManager.defaultManager;
 var err;
-var username = $.NSUserName().js
-var ffoxpath = '/Users/' + username + '/Library/Application\ Support/Firefox/Profiles';
+var ffoxpath = '/Users/' + user + '/Library/Application\ Support/Firefox/Profiles';
 if (fileMan.fileExistsAtPath(ffoxpath)){
 	let prof_folders = ObjC.deepUnwrap(fileMan.contentsOfDirectoryAtPathError(ffoxpath,$()));
 	try{

--- a/Firefox_extract_history.js
+++ b/Firefox_extract_history.js
@@ -3,12 +3,11 @@ ObjC.import('Foundation');
 app = Application.currentApplication();
 app.includeStandardAdditions = true;
 
-function history_extract(){
+function history_extract({user = $.NSUserName().js} = {}){
 	var output = "";
 	var fileMan = $.NSFileManager.defaultManager;
 	var err;
-	var username = $.NSUserName().js
-	var ffoxpath = '/Users/' + username + '/Library/Application\ Support/Firefox/Profiles';
+	var ffoxpath = '/Users/' + user + '/Library/Application\ Support/Firefox/Profiles';
 	if (fileMan.fileExistsAtPath(ffoxpath)){
 		let prof_folders = ObjC.deepUnwrap(fileMan.contentsOfDirectoryAtPathError(ffoxpath,$()));
 		try{

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This repo contains two JXA (JavaScript for Automation) scripts for extracting in
 
 > jsimport_call cookie_extract() (or jsimport_call history_extract())
 
+You can also run either cookie or history collection for a specific user, by passing their username as an option like this:
+
+> jsimport_call cookie_extract({user: "dev"}) (or jsimport_call history_extract({user: "dev"}))
+
 ![Image](ffox1.png)
 
 


### PR DESCRIPTION
In case we're running in an elevated context and NSUserName would be
root, or if we need to target a specific user's history and cookies.

Call like `jsimport_call cookie_extract({user: "jsmith"})`, based on
HealthInspector's usage. Still works well if you call without any
arguments.